### PR TITLE
Update Default (Windows).sublime-keymap

### DIFF
--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -3,7 +3,7 @@
     "keys": ["f10"],
     "command": "open_project_folder",
     "context": [
-      {"key": "setting.sublime_enhanced_keybindings", "operator": "equal", "operand": true},
+      {"key": "setting.sublime_enhanced_keybindings", "operator": "equal", "operand": true}
     ]
   },
 
@@ -11,7 +11,7 @@
     "keys": ["ctrl+f10"],
     "command": "open_file_folder",
     "context": [
-      {"key": "setting.sublime_enhanced_keybindings", "operator": "equal", "operand": true},
+      {"key": "setting.sublime_enhanced_keybindings", "operator": "equal", "operand": true}
     ]
   }
 ]


### PR DESCRIPTION
Cause an error on Windows : "Error trying to parse file: Trailing comma before closing bracket in D:...\Default (Windows).sublime-keymap:7:5"

I have Sublime Text 2 portable version 2.0.2, build 2221.
