### PR TITLE
Fixed incorrect function calls in open commands

### DIFF
--- a/OpenFilePath.py
+++ b/OpenFilePath.py
@@ -6,4 +6,4 @@ class OpenFileFolder( sublime_plugin.WindowCommand ):
     if self.window.active_view() is None:
       return
 
-    open_path.open( os.path.dirname( self.window.active_view().file_name() ) )
+    open_path.open_path( os.path.dirname( self.window.active_view().file_name() ) )

--- a/OpenProjectPath.py
+++ b/OpenProjectPath.py
@@ -3,4 +3,4 @@ import sublime_plugin
 
 class OpenProjectFolder( sublime_plugin.WindowCommand ):
   def run( self ):
-    open_path.open( self.window.folders()[0] )
+    open_path.open_path( self.window.folders()[0] )


### PR DESCRIPTION
The function open in open_path.py was renamed to open_path at
192876874239617993d007fcbab03f6b888f583f.

Using the incorrect function name caused this error in Windows:
File "OpenProjectPath in C:\...\Sublime Text 3\Installed
Packages\OpenPath.sublime-package", line 6, in run
AttributeError: 'module' object has no attribute 'open'